### PR TITLE
Add interview QA ebook scaffolding

### DIFF
--- a/interview-qa/CN/Makefile
+++ b/interview-qa/CN/Makefile
@@ -1,0 +1,48 @@
+OS := $(shell uname)
+
+ifeq ($(OS), Linux)
+	MAIN_FONT = DejaVu Serif
+	CJK_FONT = Noto Sans CJK SC
+	PANDOC_CMD = pandoc
+	RM_CMD = rm -rvf
+else ifeq ($(OS), Darwin)
+	MAIN_FONT = Times New Roman
+	CJK_FONT = PingFang SC
+	PANDOC_CMD = pandoc
+	RM_CMD = rm -rvf
+else ifeq ($(OS), Windows_NT)
+	MAIN_FONT = Times New Roman
+	CJK_FONT = Microsoft YaHei
+	PANDOC_CMD = pandoc.exe
+	RM_CMD = del /Q
+endif
+
+CHAPTERS = chapters/00-Index.md \
+		   chapters/01-Operations-SRE.md \
+		   chapters/02-DevOps.md \
+		   chapters/03-Observability.md \
+		   chapters/04-AI-Ops-Agent-LLM-Ops.md
+
+all: Interview-QA-Guide.html Interview-QA-Guide.pdf Interview-QA-Guide.docx
+
+Interview-QA-Guide.html: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o Interview-QA-Guide.html \
+		--toc --toc-depth=3 \
+		--variable mainfont="$(MAIN_FONT)" \
+		--variable CJKmainfont="$(CJK_FONT)" \
+		--variable fontsize=12pt
+
+Interview-QA-Guide.pdf: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o Interview-QA-Guide.pdf --pdf-engine=xelatex \
+		--variable mainfont="$(MAIN_FONT)" \
+		--variable CJKmainfont="$(CJK_FONT)" \
+		--variable geometry:margin=1in \
+		--variable fontsize=12pt
+
+Interview-QA-Guide.docx: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o Interview-QA-Guide.docx \
+		--variable mainfont="$(MAIN_FONT)" \
+		--variable fontsize=12pt
+
+clean:
+	$(RM_CMD) *.aux *.log *.out *.toc *.pdf *.docx *.html

--- a/interview-qa/CN/ai-ops-agent-llm-ops/Agent-Design.md
+++ b/interview-qa/CN/ai-ops-agent-llm-ops/Agent-Design.md
@@ -1,0 +1,3 @@
+# Agent Design
+
+Guidelines for designing LLM-powered agents for operations.

--- a/interview-qa/CN/ai-ops-agent-llm-ops/Eval-&-Guardrails.md
+++ b/interview-qa/CN/ai-ops-agent-llm-ops/Eval-&-Guardrails.md
@@ -1,0 +1,3 @@
+# Evaluation & Guardrails
+
+Notes on evaluating agent performance and enforcing guardrails.

--- a/interview-qa/CN/ai-ops-agent-llm-ops/QAs.md
+++ b/interview-qa/CN/ai-ops-agent-llm-ops/QAs.md
@@ -1,0 +1,3 @@
+# AI Ops & Agent LLM Ops Q&A
+
+Placeholder for AI Ops interview questions and answers.

--- a/interview-qa/CN/ai-ops-agent-llm-ops/README.md
+++ b/interview-qa/CN/ai-ops-agent-llm-ops/README.md
@@ -1,0 +1,3 @@
+# AI Ops & Agent LLM Ops
+
+Overview for AI-driven operations and agent-based LLM operations.

--- a/interview-qa/CN/chapters/00-Index.md
+++ b/interview-qa/CN/chapters/00-Index.md
@@ -1,0 +1,3 @@
+# Interview QA Guide
+
+This guide aggregates interview materials across operations, DevOps, observability, and AI Ops domains.

--- a/interview-qa/CN/chapters/01-Operations-SRE.md
+++ b/interview-qa/CN/chapters/01-Operations-SRE.md
@@ -1,0 +1,7 @@
+## Operations & SRE
+
+[README](../operations-sre/README.md)
+
+[Q&A](../operations-sre/QAs.md)
+
+[Whiteboard](../operations-sre/Whiteboard.md)

--- a/interview-qa/CN/chapters/02-DevOps.md
+++ b/interview-qa/CN/chapters/02-DevOps.md
@@ -1,0 +1,7 @@
+## DevOps
+
+[README](../devops/README.md)
+
+[Q&A](../devops/QAs.md)
+
+[Pipeline Examples](../devops/Pipelines.md)

--- a/interview-qa/CN/chapters/03-Observability.md
+++ b/interview-qa/CN/chapters/03-Observability.md
@@ -1,0 +1,7 @@
+## Observability
+
+[README](../observability/README.md)
+
+[Q&A](../observability/QAs.md)
+
+[SLI/SLO](../observability/SLI-SLO.md)

--- a/interview-qa/CN/chapters/04-AI-Ops-Agent-LLM-Ops.md
+++ b/interview-qa/CN/chapters/04-AI-Ops-Agent-LLM-Ops.md
@@ -1,0 +1,9 @@
+## AI Ops & Agent LLM Ops
+
+[README](../ai-ops-agent-llm-ops/README.md)
+
+[Q&A](../ai-ops-agent-llm-ops/QAs.md)
+
+[Agent Design](../ai-ops-agent-llm-ops/Agent-Design.md)
+
+[Evaluation & Guardrails](../ai-ops-agent-llm-ops/Eval-&-Guardrails.md)

--- a/interview-qa/CN/devops/Pipelines.md
+++ b/interview-qa/CN/devops/Pipelines.md
@@ -1,0 +1,3 @@
+# Pipeline Examples
+
+Examples for Jenkins, GitLab, or ArgoCD pipelines.

--- a/interview-qa/CN/devops/QAs.md
+++ b/interview-qa/CN/devops/QAs.md
@@ -1,0 +1,3 @@
+# DevOps Q&A
+
+Placeholder for DevOps interview questions and answers.

--- a/interview-qa/CN/devops/README.md
+++ b/interview-qa/CN/devops/README.md
@@ -1,0 +1,3 @@
+# DevOps
+
+Overview for DevOps practices and tooling.

--- a/interview-qa/CN/devops/Templates/.gitkeep
+++ b/interview-qa/CN/devops/Templates/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for devops templates

--- a/interview-qa/CN/observability/Dashboards/.gitkeep
+++ b/interview-qa/CN/observability/Dashboards/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for observability dashboards

--- a/interview-qa/CN/observability/QAs.md
+++ b/interview-qa/CN/observability/QAs.md
@@ -1,0 +1,3 @@
+# Observability Q&A
+
+Placeholder for observability interview questions and answers.

--- a/interview-qa/CN/observability/README.md
+++ b/interview-qa/CN/observability/README.md
@@ -1,0 +1,3 @@
+# Observability
+
+Overview for observability practices and tools.

--- a/interview-qa/CN/observability/SLI-SLO.md
+++ b/interview-qa/CN/observability/SLI-SLO.md
@@ -1,0 +1,3 @@
+# SLI/SLO
+
+Notes on defining service level indicators and objectives.

--- a/interview-qa/CN/operations-sre/Artifacts/.gitkeep
+++ b/interview-qa/CN/operations-sre/Artifacts/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for operations-sre artifacts

--- a/interview-qa/CN/operations-sre/QAs.md
+++ b/interview-qa/CN/operations-sre/QAs.md
@@ -1,0 +1,3 @@
+# Operations & SRE Q&A
+
+Placeholder for common interview questions and answers.

--- a/interview-qa/CN/operations-sre/README.md
+++ b/interview-qa/CN/operations-sre/README.md
@@ -1,0 +1,3 @@
+# Operations & SRE
+
+Overview for operations and site reliability engineering.

--- a/interview-qa/CN/operations-sre/Whiteboard.md
+++ b/interview-qa/CN/operations-sre/Whiteboard.md
@@ -1,0 +1,3 @@
+# Operations & SRE Whiteboard
+
+Space for diagramming and design questions.


### PR DESCRIPTION
## Summary
- move interview QA content into `CN` tree with operations-sre, devops, observability, and ai-ops-agent-llm-ops sections
- update chapter links to reference the new directory structure
- keep pandoc Makefile for building localized HTML/PDF/DOCX outputs

## Testing
- `apt-get update`
- `apt-get install -y pandoc`
- `make -C interview-qa/CN Interview-QA-Guide.html`


------
https://chatgpt.com/codex/tasks/task_e_68c42afacae883329711c2f55793253c