### PR TITLE
fix: ensure rsync step runs

### DIFF
--- a/.github/workflows/publish-documents.yml
+++ b/.github/workflows/publish-documents.yml
@@ -83,7 +83,7 @@ jobs:
           sudo apt-get install -y rsync openssh-client
 
       - name: Init SSH
-        if: env.RSYNC_SSH_KEY != ''
+        if: ${{ env.RSYNC_SSH_KEY != '' }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
@@ -92,7 +92,7 @@ jobs:
           ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts
 
       - name: Rsync release assets to remote
-        if: env.RSYNC_SSH_KEY != ''
+        if: ${{ env.RSYNC_SSH_KEY != '' }}
         run: |
           set -euo pipefail
           REMOTE_DIR="${REMOTE_ROOT}/${TAG_NAME}"


### PR DESCRIPTION
## Summary
- ensure rsync-related steps only run when SSH key is provided

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 200}, truthy: disable}}' .github/workflows/publish-documents.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c8338a11b48332b1721955acc632ff