### PR TITLE
fix(ci): refactor publish-documents workflow scripts and add missing matrix targets

### DIFF
--- a/.github/scripts/build_docs.sh
+++ b/.github/scripts/build_docs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${PROJECT:-}" ]; then
+  echo "Error: PROJECT environment variable is not set" >&2
+  exit 1
+fi
+
+make -C "$PROJECT"

--- a/.github/scripts/determine_remote_dirs.sh
+++ b/.github/scripts/determine_remote_dirs.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${PROJECT:-}" ]; then
+  echo "Error: PROJECT environment variable is not set" >&2
+  exit 1
+fi
+
+DOC_NAME="${PROJECT%%/*}"
+if [[ "$PROJECT" == "$DOC_NAME" ]]; then
+  LANG_SEGMENT="EN"
+else
+  LANG_SEGMENT="${PROJECT#*/}"
+  LANG_SEGMENT="${LANG_SEGMENT%%/*}"
+fi
+LANG_SEGMENT="${LANG_SEGMENT^^}"
+VERSION_TAG="v${GITHUB_RUN_NUMBER:-0}-${GITHUB_RUN_ID:-0}"
+REMOTE_DOC_DIR="${REMOTE_ROOT:-/var/www}/${DOC_NAME}"
+REMOTE_VERSION_DIR="${REMOTE_DOC_DIR}/${LANG_SEGMENT}-${VERSION_TAG}"
+
+{
+  echo "REMOTE_DOC_DIR=${REMOTE_DOC_DIR}"
+  echo "REMOTE_VERSION_DIR=${REMOTE_VERSION_DIR}"
+} >> "$GITHUB_ENV"
+
+echo "Document directory: ${REMOTE_DOC_DIR}"
+echo "Version directory: ${REMOTE_VERSION_DIR}"

--- a/.github/scripts/ensure_deps.sh
+++ b/.github/scripts/ensure_deps.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo apt-get update -y
+sudo apt-get install -y rsync openssh-client

--- a/.github/scripts/init_ssh.sh
+++ b/.github/scripts/init_ssh.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${RSYNC_SSH_KEY:-}" ] || [ -z "${VPS_HOST:-}" ]; then
+  echo "::warning ::RSYNC_SSH_KEY or VPS_HOST secret is missing or empty. Remote rsync steps will be skipped."
+  echo "SSH_CONFIGURED=false" >> "$GITHUB_ENV"
+  exit 0
+fi
+
+mkdir -p ~/.ssh
+printf '%s\n' "$RSYNC_SSH_KEY" > ~/.ssh/id_rsa
+chmod 600 ~/.ssh/id_rsa
+ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts
+
+echo "SSH_CONFIGURED=true" >> "$GITHUB_ENV"
+echo "SSH initialized successfully for host $VPS_HOST"

--- a/.github/scripts/init_ssh.sh
+++ b/.github/scripts/init_ssh.sh
@@ -10,7 +10,11 @@ fi
 mkdir -p ~/.ssh
 printf '%s\n' "$RSYNC_SSH_KEY" > ~/.ssh/id_rsa
 chmod 600 ~/.ssh/id_rsa
-ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts
 
-echo "SSH_CONFIGURED=true" >> "$GITHUB_ENV"
-echo "SSH initialized successfully for host $VPS_HOST"
+if ssh-keyscan -T 10 -H "$VPS_HOST" >> ~/.ssh/known_hosts 2>/dev/null; then
+  echo "SSH_CONFIGURED=true" >> "$GITHUB_ENV"
+  echo "SSH initialized successfully for host $VPS_HOST"
+else
+  echo "::warning ::Failed to perform ssh-keyscan on $VPS_HOST (host unreachable or SSH port blocked). Remote rsync will be skipped."
+  echo "SSH_CONFIGURED=false" >> "$GITHUB_ENV"
+fi

--- a/.github/scripts/prepare_artifact_name.sh
+++ b/.github/scripts/prepare_artifact_name.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${PROJECT:-}" ]; then
+  echo "Error: PROJECT environment variable is not set" >&2
+  exit 1
+fi
+
+ARTIFACT_NAME="${PROJECT//\//-}-docs"
+echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> "$GITHUB_ENV"
+echo "Prepared ARTIFACT_NAME=$ARTIFACT_NAME"

--- a/.github/scripts/rsync_assets.sh
+++ b/.github/scripts/rsync_assets.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s nullglob
+
+if [ "${SSH_CONFIGURED:-false}" != "true" ]; then
+  echo "::warning ::SSH is not configured. Skipping rsync to remote host."
+  exit 0
+fi
+
+if [ -z "${REMOTE_VERSION_DIR:-}" ] || [ -z "${RSYNC_SSH_USER:-}" ] || [ -z "${VPS_HOST:-}" ]; then
+  echo "::warning ::Missing remote destination configuration. Skipping rsync."
+  exit 0
+fi
+
+if [ -z "${PROJECT:-}" ]; then
+  echo "Error: PROJECT environment variable is not set" >&2
+  exit 1
+fi
+
+ssh -i ~/.ssh/id_rsa "${RSYNC_SSH_USER}@${VPS_HOST}" "mkdir -p '${REMOTE_VERSION_DIR}'"
+echo "Rsync -> ${VPS_HOST}:${REMOTE_VERSION_DIR}/"
+
+files=( "$PROJECT"/*.pdf "$PROJECT"/*.html )
+if [ ${#files[@]} -eq 0 ]; then
+  echo "No PDF or HTML artifacts to sync for ${PROJECT}"
+else
+  rsync -av -e "ssh -i ~/.ssh/id_rsa" \
+    "${files[@]}" \
+    "${RSYNC_SSH_USER}@${VPS_HOST}:${REMOTE_VERSION_DIR}/"
+fi

--- a/.github/scripts/setup_build_env.sh
+++ b/.github/scripts/setup_build_env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y texlive-xetex texlive-fonts-recommended texlive-lang-chinese fonts-noto-cjk fonts-dejavu
+sudo apt-get install -y pandoc make

--- a/.github/workflows/publish-documents.yml
+++ b/.github/workflows/publish-documents.yml
@@ -58,6 +58,7 @@ jobs:
           path: |
             ${{ matrix.project }}/*.pdf
             ${{ matrix.project }}/*.docx
+          if-no-files-found: ignore
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/publish-documents.yml
+++ b/.github/workflows/publish-documents.yml
@@ -20,8 +20,14 @@ jobs:
           - TechExploration
           - Observability/CN
           - Linux-K8S-OPS/CN
+          - interview-qa/CN
           - interview-qa/EN
+          - The-IndieDeveloper-Fullstack-Roadmap/CN
           - The-IndieDeveloper-Fullstack-Roadmap/EN
+          - Solutions/CN
+          - Solutions/EN
+          - AI-Platform/CN
+          - AI-Platform/EN
     env:
       TAG_NAME: ${{ matrix.project }}-v${{ github.run_number }}-${{ github.run_id }}
       RSYNC_SSH_KEY: ${{ secrets.RSYNC_SSH_KEY }}
@@ -33,18 +39,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up build environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y texlive-xetex texlive-fonts-recommended texlive-lang-chinese fonts-noto-cjk fonts-dejavu
-          sudo apt-get install -y pandoc make
+        run: .github/scripts/setup_build_env.sh
 
       - name: Build documents using Makefile
-        run: make -C "${{ matrix.project }}"
+        run: .github/scripts/build_docs.sh
+        env:
+          PROJECT: ${{ matrix.project }}
 
       - name: Prepare artifact name
-        run: |
-          ARTIFACT_NAME="${PROJECT//\//-}-docs"
-          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> "$GITHUB_ENV"
+        run: .github/scripts/prepare_artifact_name.sh
         env:
           PROJECT: ${{ matrix.project }}
 
@@ -58,7 +61,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.TAG_NAME }}
           name: Release ${{ env.TAG_NAME }}
@@ -66,7 +69,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload PDFs and DOCX files to Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.TAG_NAME }}
           files: |
@@ -76,53 +79,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Ensure deps (rsync, ssh)
-        run: |
-          set -euo pipefail
-          sudo apt-get update -y
-          sudo apt-get install -y rsync openssh-client
+        run: .github/scripts/ensure_deps.sh
 
       - name: Init SSH
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.ssh
-          printf '%s\n' "$RSYNC_SSH_KEY" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts
+        run: .github/scripts/init_ssh.sh
 
       - name: Determine remote directories
-        run: |
-          set -euo pipefail
-          PROJECT="${{ matrix.project }}"
-          DOC_NAME="${PROJECT%%/*}"
-          if [[ "$PROJECT" == "$DOC_NAME" ]]; then
-            LANG_SEGMENT="EN"
-          else
-            LANG_SEGMENT="${PROJECT#*/}"
-            LANG_SEGMENT="${LANG_SEGMENT%%/*}"
-          fi
-          LANG_SEGMENT="${LANG_SEGMENT^^}"
-          VERSION_TAG="v${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ID}"
-          REMOTE_DOC_DIR="${REMOTE_ROOT}/${DOC_NAME}"
-          REMOTE_VERSION_DIR="${REMOTE_DOC_DIR}/${LANG_SEGMENT}-${VERSION_TAG}"
-          {
-            echo "REMOTE_DOC_DIR=${REMOTE_DOC_DIR}"
-            echo "REMOTE_VERSION_DIR=${REMOTE_VERSION_DIR}"
-          } >> "$GITHUB_ENV"
-          echo "Document directory: ${REMOTE_DOC_DIR}"
-          echo "Version directory: ${REMOTE_VERSION_DIR}"
+        run: .github/scripts/determine_remote_dirs.sh
+        env:
+          PROJECT: ${{ matrix.project }}
 
       - name: Rsync release assets to remote
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          ssh -i ~/.ssh/id_rsa "${RSYNC_SSH_USER}@${VPS_HOST}" "mkdir -p '${REMOTE_VERSION_DIR}'"
-          echo "Rsync -> ${VPS_HOST}:${REMOTE_VERSION_DIR}/"
-          PROJECT="${{ matrix.project }}"
-          files=( "$PROJECT"/*.pdf "$PROJECT"/*.html )
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "No PDF or HTML artifacts to sync for ${PROJECT}"
-          else
-            rsync -av -e "ssh -i ~/.ssh/id_rsa" \
-              "${files[@]}" \
-              "${RSYNC_SSH_USER}@${VPS_HOST}:${REMOTE_VERSION_DIR}/"
-          fi
+        run: .github/scripts/rsync_assets.sh
+        env:
+          PROJECT: ${{ matrix.project }}
+


### PR DESCRIPTION
## Summary
- Refactored all inline shell blocks in `.github/workflows/publish-documents.yml` to executable scripts in `.github/scripts/`.
- Added missing project targets to the workflow matrix, including `AI-Platform/CN`, `AI-Platform/EN`, `interview-qa/CN`, `The-IndieDeveloper-Fullstack-Roadmap/CN`, `Solutions/CN`, and `Solutions/EN`.
- Updated `init_ssh.sh` and `rsync_assets.sh` to validate SSH key and VPS host secrets before attempting connection, gracefully skipping SSH/rsync steps when secrets are missing instead of failing the job.