### PR TITLE
fix(ci): complete GitHub Release artifact outputs with HTML and recursive subfolders

### DIFF
--- a/.github/scripts/build_docs.sh
+++ b/.github/scripts/build_docs.sh
@@ -6,4 +6,10 @@ if [ -z "${PROJECT:-}" ]; then
   exit 1
 fi
 
-make -C "$PROJECT"
+if make -C "$PROJECT" -n all >/dev/null 2>&1; then
+  echo "Building 'all' target for $PROJECT"
+  make -C "$PROJECT" all
+else
+  echo "Building default target for $PROJECT"
+  make -C "$PROJECT"
+fi

--- a/.github/workflows/publish-documents.yml
+++ b/.github/workflows/publish-documents.yml
@@ -51,13 +51,14 @@ jobs:
         env:
           PROJECT: ${{ matrix.project }}
 
-      - name: Upload PDFs and DOCX files to GitHub Artifacts
+      - name: Upload PDF, DOCX, and HTML files to GitHub Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: |
-            ${{ matrix.project }}/*.pdf
-            ${{ matrix.project }}/*.docx
+            ${{ matrix.project }}/**/*.pdf
+            ${{ matrix.project }}/**/*.docx
+            ${{ matrix.project }}/**/*.html
           if-no-files-found: ignore
 
       - name: Create Release
@@ -69,15 +70,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload PDFs and DOCX files to Release
+      - name: Upload PDF, DOCX, and HTML files to Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.TAG_NAME }}
           files: |
-            ${{ matrix.project }}/*.pdf
-            ${{ matrix.project }}/*.docx
+            ${{ matrix.project }}/**/*.pdf
+            ${{ matrix.project }}/**/*.docx
+            ${{ matrix.project }}/**/*.html
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 
       - name: Ensure deps (rsync, ssh)
         run: .github/scripts/ensure_deps.sh

--- a/AI-Platform/CN/Makefile
+++ b/AI-Platform/CN/Makefile
@@ -21,29 +21,30 @@ endif
 # 章节文件列表
 CHAPTERS := $(sort $(wildcard chapters/*.md))
 
-all: Observability-Guide.html Observability-Guide.pdf Observability-Guide.docx
+all: AI-Platform-Guide.html AI-Platform-Guide.pdf AI-Platform-Guide.docx
 
 # 目标：生成 HTML 电子书
-Observability-Guide.html: $(CHAPTERS)
-	$(PANDOC_CMD) $(CHAPTERS) -o Observability-Design-and-Implementation.html \
+AI-Platform-Guide.html: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o AI-Platform-Design-and-Implementation.html \
 		--toc --toc-depth=3                  \
 		--variable mainfont="$(MAIN_FONT)"   \
 		--variable CJKmainfont="$(CJK_FONT)" \
 		--variable fontsize=12pt
 
 # 目标：生成 PDF 电子书
-Observability-Guide.pdf: $(CHAPTERS)
-	$(PANDOC_CMD) $(CHAPTERS) -o Observability-Design-and-Implementation.pdf --pdf-engine=xelatex \
+AI-Platform-Guide.pdf: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o AI-Platform-Design-and-Implementation.pdf --pdf-engine=xelatex \
 		--variable mainfont="$(MAIN_FONT)"   \
 		--variable CJKmainfont="$(CJK_FONT)" \
 		--variable geometry:margin=1in       \
 		--variable fontsize=12pt
 
 # 目标：生成 DOCX 电子书
-Observability-Guide.docx: $(CHAPTERS)
-	$(PANDOC_CMD) $(CHAPTERS) -o Observability-Guide.docx \
+AI-Platform-Guide.docx: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o AI-Platform-Guide.docx \
 		--variable mainfont="$(MAIN_FONT)" \
 		--variable fontsize=12pt
+
 
 # 清理中间文件
 clean:

--- a/AI-Platform/EN/Makefile
+++ b/AI-Platform/EN/Makefile
@@ -21,29 +21,30 @@ endif
 # 章节文件列表
 CHAPTERS := $(sort $(wildcard chapters/*.md))
 
-all: Observability-Guide.html Observability-Guide.pdf Observability-Guide.docx
+all: AI-Platform-Guide.html AI-Platform-Guide.pdf AI-Platform-Guide.docx
 
 # 目标：生成 HTML 电子书
-Observability-Guide.html: $(CHAPTERS)
-	$(PANDOC_CMD) $(CHAPTERS) -o Observability-Design-and-Implementation.html \
+AI-Platform-Guide.html: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o AI-Platform-Design-and-Implementation.html \
 		--toc --toc-depth=3                  \
 		--variable mainfont="$(MAIN_FONT)"   \
 		--variable CJKmainfont="$(CJK_FONT)" \
 		--variable fontsize=12pt
 
 # 目标：生成 PDF 电子书
-Observability-Guide.pdf: $(CHAPTERS)
-	$(PANDOC_CMD) $(CHAPTERS) -o Observability-Design-and-Implementation.pdf --pdf-engine=xelatex \
+AI-Platform-Guide.pdf: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o AI-Platform-Design-and-Implementation.pdf --pdf-engine=xelatex \
 		--variable mainfont="$(MAIN_FONT)"   \
 		--variable CJKmainfont="$(CJK_FONT)" \
 		--variable geometry:margin=1in       \
 		--variable fontsize=12pt
 
 # 目标：生成 DOCX 电子书
-Observability-Guide.docx: $(CHAPTERS)
-	$(PANDOC_CMD) $(CHAPTERS) -o Observability-Guide.docx \
+AI-Platform-Guide.docx: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o AI-Platform-Guide.docx \
 		--variable mainfont="$(MAIN_FONT)" \
 		--variable fontsize=12pt
+
 
 # 清理中间文件
 clean:

--- a/Keycloak/Makefile
+++ b/Keycloak/Makefile
@@ -21,6 +21,10 @@ endif
 # 章节文件列表
 CHAPTERS := $(sort $(wildcard chapters/*.md))
 
+.PHONY: all clean book.html book.pdf book.docx
+
+all: book.html book.pdf book.docx
+
 # 目标：生成 HTML 电子书
 book.html: $(CHAPTERS)
 	$(PANDOC_CMD) $(CHAPTERS) -o Keycloak-SSO-Design-and-Implementation.html \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,12 @@ SUBDIRS = \
     interview-qa/CN \
     interview-qa/EN \
     The-IndieDeveloper-Fullstack-Roadmap/EN \
-    The-IndieDeveloper-Fullstack-Roadmap/CN
+    The-IndieDeveloper-Fullstack-Roadmap/CN \
+    Solutions/CN \
+    Solutions/EN \
+    AI-Platform/CN \
+    AI-Platform/EN
+
 
 .PHONY: all $(SUBDIRS)
 

--- a/Solutions/CN/Makefile
+++ b/Solutions/CN/Makefile
@@ -21,29 +21,30 @@ endif
 # 章节文件列表
 CHAPTERS := $(sort $(wildcard chapters/*.md))
 
-all: Observability-Guide.html Observability-Guide.pdf Observability-Guide.docx
+all: Solutions-Guide.html Solutions-Guide.pdf Solutions-Guide.docx
 
 # 目标：生成 HTML 电子书
-Observability-Guide.html: $(CHAPTERS)
-	$(PANDOC_CMD) $(CHAPTERS) -o Observability-Design-and-Implementation.html \
+Solutions-Guide.html: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o Solutions-Design-and-Implementation.html \
 		--toc --toc-depth=3                  \
 		--variable mainfont="$(MAIN_FONT)"   \
 		--variable CJKmainfont="$(CJK_FONT)" \
 		--variable fontsize=12pt
 
 # 目标：生成 PDF 电子书
-Observability-Guide.pdf: $(CHAPTERS)
-	$(PANDOC_CMD) $(CHAPTERS) -o Observability-Design-and-Implementation.pdf --pdf-engine=xelatex \
+Solutions-Guide.pdf: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o Solutions-Design-and-Implementation.pdf --pdf-engine=xelatex \
 		--variable mainfont="$(MAIN_FONT)"   \
 		--variable CJKmainfont="$(CJK_FONT)" \
 		--variable geometry:margin=1in       \
 		--variable fontsize=12pt
 
 # 目标：生成 DOCX 电子书
-Observability-Guide.docx: $(CHAPTERS)
-	$(PANDOC_CMD) $(CHAPTERS) -o Observability-Guide.docx \
+Solutions-Guide.docx: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o Solutions-Guide.docx \
 		--variable mainfont="$(MAIN_FONT)" \
 		--variable fontsize=12pt
+
 
 # 清理中间文件
 clean:

--- a/Solutions/EN/Makefile
+++ b/Solutions/EN/Makefile
@@ -21,29 +21,30 @@ endif
 # 章节文件列表
 CHAPTERS := $(sort $(wildcard chapters/*.md))
 
-all: Observability-Guide.html Observability-Guide.pdf Observability-Guide.docx
+all: Solutions-Guide.html Solutions-Guide.pdf Solutions-Guide.docx
 
 # 目标：生成 HTML 电子书
-Observability-Guide.html: $(CHAPTERS)
-	$(PANDOC_CMD) $(CHAPTERS) -o Observability-Design-and-Implementation.html \
+Solutions-Guide.html: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o Solutions-Design-and-Implementation.html \
 		--toc --toc-depth=3                  \
 		--variable mainfont="$(MAIN_FONT)"   \
 		--variable CJKmainfont="$(CJK_FONT)" \
 		--variable fontsize=12pt
 
 # 目标：生成 PDF 电子书
-Observability-Guide.pdf: $(CHAPTERS)
-	$(PANDOC_CMD) $(CHAPTERS) -o Observability-Design-and-Implementation.pdf --pdf-engine=xelatex \
+Solutions-Guide.pdf: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o Solutions-Design-and-Implementation.pdf --pdf-engine=xelatex \
 		--variable mainfont="$(MAIN_FONT)"   \
 		--variable CJKmainfont="$(CJK_FONT)" \
 		--variable geometry:margin=1in       \
 		--variable fontsize=12pt
 
 # 目标：生成 DOCX 电子书
-Observability-Guide.docx: $(CHAPTERS)
-	$(PANDOC_CMD) $(CHAPTERS) -o Observability-Guide.docx \
+Solutions-Guide.docx: $(CHAPTERS)
+	$(PANDOC_CMD) $(CHAPTERS) -o Solutions-Guide.docx \
 		--variable mainfont="$(MAIN_FONT)" \
 		--variable fontsize=12pt
+
 
 # 清理中间文件
 clean:


### PR DESCRIPTION
## Summary
- Updated GitHub Artifacts and GitHub Release upload patterns to include `**/*.pdf`, `**/*.docx`, and `**/*.html`.
- Updated `build_docs.sh` to invoke `make -C "$PROJECT" all` when available.
- Added `all:` target to `Keycloak/Makefile`.
- Fixed output target filenames in `AI-Platform` and `Solutions` Makefiles.
- Added all subdirectories to root `Makefile`.