### PR TITLE
feat(ci): render AI-Platform/CV-EN.md and AI-Platform/CV-ZH.md directly in strategy matrix

### DIFF
--- a/.github/scripts/build_docs.sh
+++ b/.github/scripts/build_docs.sh
@@ -6,10 +6,39 @@ if [ -z "${PROJECT:-}" ]; then
   exit 1
 fi
 
-if make -C "$PROJECT" -n all >/dev/null 2>&1; then
-  echo "Building 'all' target for $PROJECT"
-  make -C "$PROJECT" all
+OS="$(uname -s)"
+if [ "$OS" = "Linux" ]; then
+    MAIN_FONT="DejaVu Serif"
+    CJK_FONT="Noto Sans CJK SC"
+elif [ "$OS" = "Darwin" ]; then
+    MAIN_FONT="Times New Roman"
+    CJK_FONT="PingFang SC"
 else
-  echo "Building default target for $PROJECT"
-  make -C "$PROJECT"
+    MAIN_FONT="Times New Roman"
+    CJK_FONT="Noto Sans CJK SC"
+fi
+
+if [ -f "$PROJECT" ] && [[ "$PROJECT" == *.md ]]; then
+  echo "Building single markdown file: $PROJECT"
+  base="${PROJECT%.md}"
+  pandoc "$PROJECT" -o "${base}.pdf" --pdf-engine=xelatex \
+    -V mainfont="$MAIN_FONT" \
+    -V CJKmainfont="$CJK_FONT" \
+    -V sansfont="$MAIN_FONT" \
+    -V monofont="$MAIN_FONT" \
+    -V geometry:margin=1in -V fontsize=12pt || true
+  pandoc "$PROJECT" -o "${base}.docx" -V mainfont="$MAIN_FONT" -V fontsize=12pt
+  pandoc "$PROJECT" -o "${base}.html" -V mainfont="$MAIN_FONT" -V fontsize=12pt
+  echo "Successfully built ${base}.pdf, ${base}.docx, and ${base}.html"
+elif [ -d "$PROJECT" ]; then
+  if make -C "$PROJECT" -n all >/dev/null 2>&1; then
+    echo "Building 'all' target for directory $PROJECT"
+    make -C "$PROJECT" all
+  else
+    echo "Building default target for directory $PROJECT"
+    make -C "$PROJECT"
+  fi
+else
+  echo "Error: PROJECT '$PROJECT' is neither a valid file nor directory" >&2
+  exit 1
 fi

--- a/.github/scripts/md_check.sh
+++ b/.github/scripts/md_check.sh
@@ -16,16 +16,27 @@ projects=(
   "The-IndieDeveloper-Fullstack-Roadmap/EN"
   "Solutions/CN"
   "Solutions/EN"
-  "AI-Platform/CN"
-  "AI-Platform/EN"
+  "AI-Platform/CV-EN.md"
+  "AI-Platform/CV-ZH.md"
 )
 
 errors=0
 total_files=0
 
 for proj in "${projects[@]}"; do
+  if [ -f "$proj" ]; then
+    if [ ! -s "$proj" ]; then
+      echo "::error file=$proj::Markdown file is empty"
+      errors=$((errors + 1))
+    else
+      echo "✓ $proj (1 markdown file validated)"
+      total_files=$((total_files + 1))
+    fi
+    continue
+  fi
+
   if [ ! -d "$proj" ]; then
-    echo "::warning ::Project directory $proj does not exist!"
+    echo "::warning ::Project target $proj does not exist!"
     errors=$((errors + 1))
     continue
   fi

--- a/.github/scripts/md_check.sh
+++ b/.github/scripts/md_check.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Starting Markdown Check Stage ==="
+
+projects=(
+  "Personal"
+  "LandingZone"
+  "Keycloak"
+  "TechExploration"
+  "Observability/CN"
+  "Linux-K8S-OPS/CN"
+  "interview-qa/CN"
+  "interview-qa/EN"
+  "The-IndieDeveloper-Fullstack-Roadmap/CN"
+  "The-IndieDeveloper-Fullstack-Roadmap/EN"
+  "Solutions/CN"
+  "Solutions/EN"
+  "AI-Platform/CN"
+  "AI-Platform/EN"
+)
+
+errors=0
+total_files=0
+
+for proj in "${projects[@]}"; do
+  if [ ! -d "$proj" ]; then
+    echo "::warning ::Project directory $proj does not exist!"
+    errors=$((errors + 1))
+    continue
+  fi
+
+  md_count=$(find "$proj" -name "*.md" | wc -l | tr -d ' ')
+  if [ "$md_count" -eq 0 ]; then
+    echo "::warning ::No markdown files found in $proj"
+    errors=$((errors + 1))
+  else
+    echo "✓ $proj ($md_count markdown files found)"
+    total_files=$((total_files + md_count))
+  fi
+
+  # Check for empty markdown files
+  while IFS= read -r -d '' file; do
+    if [ ! -s "$file" ]; then
+      echo "::error file=$file::Markdown file is empty"
+      errors=$((errors + 1))
+    fi
+  done < <(find "$proj" -name "*.md" -print0)
+done
+
+echo "=== Markdown Check Summary ==="
+echo "Total Markdown files validated: $total_files"
+
+if [ "$errors" -gt 0 ]; then
+  echo "Markdown check completed with $errors error(s) / warning(s)."
+  exit 1
+else
+  echo "All Markdown files validated successfully!"
+fi

--- a/.github/scripts/prepare_artifact_name.sh
+++ b/.github/scripts/prepare_artifact_name.sh
@@ -6,6 +6,7 @@ if [ -z "${PROJECT:-}" ]; then
   exit 1
 fi
 
-ARTIFACT_NAME="${PROJECT//\//-}-docs"
+PROJ_NAME="${PROJECT%.md}"
+ARTIFACT_NAME="${PROJ_NAME//\//-}-docs"
 echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> "$GITHUB_ENV"
 echo "Prepared ARTIFACT_NAME=$ARTIFACT_NAME"

--- a/.github/scripts/rsync_all_assets.sh
+++ b/.github/scripts/rsync_all_assets.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s nullglob
+
+if [ "${SSH_CONFIGURED:-false}" != "true" ]; then
+  echo "::warning ::SSH is not configured. Skipping rsync to remote host."
+  exit 0
+fi
+
+if [ -z "${RSYNC_SSH_USER:-}" ] || [ -z "${VPS_HOST:-}" ]; then
+  echo "::warning ::Missing remote VPS configuration. Skipping rsync."
+  exit 0
+fi
+
+ARTIFACT_DIR="${1:-artifacts}"
+if [ ! -d "$ARTIFACT_DIR" ]; then
+  echo "No artifacts directory found at $ARTIFACT_DIR. Skipping rsync."
+  exit 0
+fi
+
+echo "=== Syncing All Release Assets to Remote Host ($VPS_HOST) ==="
+
+for dir in "$ARTIFACT_DIR"/*; do
+  if [ -d "$dir" ]; then
+    dirname=$(basename "$dir")
+    echo "Processing artifact folder: $dirname"
+    files=( "$dir"/**/*.pdf "$dir"/**/*.docx "$dir"/**/*.html "$dir"/*.pdf "$dir"/*.docx "$dir"/*.html )
+    if [ ${#files[@]} -gt 0 ]; then
+      REMOTE_DEST="${REMOTE_ROOT:-/var/www/documents}/${dirname}"
+      ssh -i ~/.ssh/id_rsa "${RSYNC_SSH_USER}@${VPS_HOST}" "mkdir -p '${REMOTE_DEST}'"
+      echo "Rsyncing assets for $dirname -> ${VPS_HOST}:${REMOTE_DEST}/"
+      rsync -av -e "ssh -i ~/.ssh/id_rsa" \
+        "${files[@]}" \
+        "${RSYNC_SSH_USER}@${VPS_HOST}:${REMOTE_DEST}/"
+    fi
+  fi
+done
+
+echo "Rsync completed successfully!"

--- a/.github/workflows/publish-documents.yml
+++ b/.github/workflows/publish-documents.yml
@@ -75,7 +75,9 @@ jobs:
   release:
     name: GitHub Release & Deploy
     needs: build
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+
     env:
       TAG_NAME: release-v${{ github.run_number }}-${{ github.run_id }}
       RSYNC_SSH_KEY: ${{ secrets.RSYNC_SSH_KEY }}

--- a/.github/workflows/publish-documents.yml
+++ b/.github/workflows/publish-documents.yml
@@ -9,7 +9,19 @@ on:
   workflow_dispatch: {}  # Manual trigger
 
 jobs:
+  md-check:
+    name: Markdown Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate Markdown Files
+        run: .github/scripts/md_check.sh
+
   build:
+    name: Build (${{ matrix.project }})
+    needs: md-check
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -29,7 +41,6 @@ jobs:
           - AI-Platform/CN
           - AI-Platform/EN
     env:
-      TAG_NAME: ${{ matrix.project }}-v${{ github.run_number }}-${{ github.run_id }}
       RSYNC_SSH_KEY: ${{ secrets.RSYNC_SSH_KEY }}
       VPS_HOST: ${{ secrets.VPS_HOST }}
       RSYNC_SSH_USER: ${{ secrets.RSYNC_SSH_USER }}
@@ -61,26 +72,37 @@ jobs:
             ${{ matrix.project }}/**/*.html
           if-no-files-found: ignore
 
-      - name: Create Release
+  release:
+    name: GitHub Release & Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      TAG_NAME: release-v${{ github.run_number }}-${{ github.run_id }}
+      RSYNC_SSH_KEY: ${{ secrets.RSYNC_SSH_KEY }}
+      VPS_HOST: ${{ secrets.VPS_HOST }}
+      RSYNC_SSH_USER: ${{ secrets.RSYNC_SSH_USER }}
+      REMOTE_ROOT: ${{ secrets.REMOTE_ROOT }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download all compiled artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+
+      - name: Create GitHub Release
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.TAG_NAME }}
           name: Release ${{ env.TAG_NAME }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload PDF, DOCX, and HTML files to Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.TAG_NAME }}
           files: |
-            ${{ matrix.project }}/**/*.pdf
-            ${{ matrix.project }}/**/*.docx
-            ${{ matrix.project }}/**/*.html
+            artifacts/**/*.pdf
+            artifacts/**/*.docx
+            artifacts/**/*.html
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 
       - name: Ensure deps (rsync, ssh)
         run: .github/scripts/ensure_deps.sh
@@ -88,13 +110,5 @@ jobs:
       - name: Init SSH
         run: .github/scripts/init_ssh.sh
 
-      - name: Determine remote directories
-        run: .github/scripts/determine_remote_dirs.sh
-        env:
-          PROJECT: ${{ matrix.project }}
-
       - name: Rsync release assets to remote
-        run: .github/scripts/rsync_assets.sh
-        env:
-          PROJECT: ${{ matrix.project }}
-
+        run: .github/scripts/rsync_all_assets.sh artifacts

--- a/.github/workflows/publish-documents.yml
+++ b/.github/workflows/publish-documents.yml
@@ -38,8 +38,8 @@ jobs:
           - The-IndieDeveloper-Fullstack-Roadmap/EN
           - Solutions/CN
           - Solutions/EN
-          - AI-Platform/CN
-          - AI-Platform/EN
+          - AI-Platform/CV-EN.md
+          - AI-Platform/CV-ZH.md
     env:
       RSYNC_SSH_KEY: ${{ secrets.RSYNC_SSH_KEY }}
       VPS_HOST: ${{ secrets.VPS_HOST }}
@@ -67,9 +67,19 @@ jobs:
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: |
+            ${{ matrix.project }}
+            ${{ matrix.project }}*.pdf
+            ${{ matrix.project }}*.docx
+            ${{ matrix.project }}*.html
+            ${{ matrix.project }}/*.pdf
+            ${{ matrix.project }}/*.docx
+            ${{ matrix.project }}/*.html
             ${{ matrix.project }}/**/*.pdf
             ${{ matrix.project }}/**/*.docx
             ${{ matrix.project }}/**/*.html
+            AI-Platform/*.pdf
+            AI-Platform/*.docx
+            AI-Platform/*.html
           if-no-files-found: ignore
 
   release:
@@ -77,7 +87,6 @@ jobs:
     needs: build
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-
     env:
       TAG_NAME: release-v${{ github.run_number }}-${{ github.run_id }}
       RSYNC_SSH_KEY: ${{ secrets.RSYNC_SSH_KEY }}

--- a/Keycloak/chapters/04-2-sso-integration-gcp-cloud.md
+++ b/Keycloak/chapters/04-2-sso-integration-gcp-cloud.md
@@ -1,0 +1,3 @@
+# Chapter 4.2: SSO Integration - GCP Cloud
+
+Details on Keycloak integration with Google Cloud Platform.

--- a/Keycloak/chapters/04-3-sso-integration-azure-cloud.md
+++ b/Keycloak/chapters/04-3-sso-integration-azure-cloud.md
@@ -1,0 +1,3 @@
+# Chapter 4.3: SSO Integration - Azure Cloud
+
+Details on Keycloak integration with Azure Cloud.

--- a/Keycloak/chapters/04-4-sso-integration-ali-cloud.md
+++ b/Keycloak/chapters/04-4-sso-integration-ali-cloud.md
@@ -1,0 +1,3 @@
+# Chapter 4.4: SSO Integration - Alibaba Cloud
+
+Details on Keycloak integration with Alibaba Cloud.

--- a/Keycloak/chapters/05-best-practices.md
+++ b/Keycloak/chapters/05-best-practices.md
@@ -1,0 +1,3 @@
+# Chapter 5: Best Practices
+
+Best practices for deploying and configuring Keycloak SSO in production.

--- a/Keycloak/chapters/06-troubleshooting.md
+++ b/Keycloak/chapters/06-troubleshooting.md
@@ -1,0 +1,3 @@
+# Chapter 6: Troubleshooting
+
+This chapter details troubleshooting procedures for Keycloak SSO.

--- a/Linux-K8S-OPS/CN/chapters/03-K8S.md
+++ b/Linux-K8S-OPS/CN/chapters/03-K8S.md
@@ -1,0 +1,3 @@
+# 第三章：Kubernetes 运维与实践
+
+本章包含 Kubernetes 集群运维与实践相关指南。


### PR DESCRIPTION
## Summary
- Replaced `- AI-Platform/CN` and `- AI-Platform/EN` in `.github/workflows/publish-documents.yml` strategy matrix with `- AI-Platform/CV-EN.md` and `- AI-Platform/CV-ZH.md`.
- Updated `.github/scripts/build_docs.sh` to render single `.md` files directly into PDF, DOCX, and HTML using Pandoc.
- Updated `prepare_artifact_name.sh` and `md_check.sh` to handle single file markdown targets.