### PR TITLE
fix(ci): ensure unique release asset filenames to fix GitHub Release 404 upload failure

### DIFF
--- a/.github/scripts/prepare_release_assets.sh
+++ b/.github/scripts/prepare_release_assets.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SRC_DIR="${1:-artifacts}"
+DST_DIR="${2:-release_assets}"
+
+mkdir -p "$DST_DIR"
+
+if [ ! -d "$SRC_DIR" ]; then
+  echo "Source directory $SRC_DIR does not exist. Skipping release assets preparation."
+  exit 0
+fi
+
+echo "=== Preparing Unique Release Assets in $DST_DIR ==="
+
+count=0
+while IFS= read -r -d '' file; do
+  rel_path="${file#"$SRC_DIR"/}"
+  flat_name="$(echo "$rel_path" | tr '/' '_')"
+  echo "Copying: $rel_path -> $DST_DIR/$flat_name"
+  cp "$file" "$DST_DIR/$flat_name"
+  count=$((count + 1))
+done < <(find "$SRC_DIR" -type f \( -name "*.pdf" -o -name "*.docx" -o -name "*.html" \) -print0)
+
+echo "Done! Prepared $count release asset(s) in $DST_DIR."

--- a/.github/workflows/publish-documents.yml
+++ b/.github/workflows/publish-documents.yml
@@ -102,6 +102,9 @@ jobs:
         with:
           path: artifacts/
 
+      - name: Prepare unique release assets
+        run: .github/scripts/prepare_release_assets.sh artifacts release_assets
+
       - name: Create GitHub Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -109,9 +112,9 @@ jobs:
           tag_name: ${{ env.TAG_NAME }}
           name: Release ${{ env.TAG_NAME }}
           files: |
-            artifacts/**/*.pdf
-            artifacts/**/*.docx
-            artifacts/**/*.html
+            release_assets/*.pdf
+            release_assets/*.docx
+            release_assets/*.html
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Fixed 404 Not Found failure during `softprops/action-gh-release@v2` release asset upload caused by duplicate asset filenames across matrix build targets (e.g. `Interview-QA-Guide.pdf`, `Solutions-Design-and-Implementation.pdf`, `CV-ZH.pdf`).
- Added `.github/scripts/prepare_release_assets.sh` script to flatten and prefix release asset filenames with their relative source directory paths (e.g., `interview-qa-CN-docs-Interview-QA-Guide.pdf`), ensuring 100% unique asset filenames.
- Updated `.github/workflows/publish-documents.yml` to run `prepare_release_assets.sh` prior to `Create GitHub Release`.